### PR TITLE
Fixed wrong .uid loading in plugin script

### DIFF
--- a/addons/locker/locker.gd
+++ b/addons/locker/locker.gd
@@ -313,7 +313,7 @@ func _disable_plugin() -> void:
 static func _load_strategy_scripts() -> Array[Script]:
 	var scripts: Array[Script] = []
 	
-	for resource: Resource in LokFileSystemUtil.load_resources(STRATEGY_SCRIPTS_PATH):
+	for resource: Resource in LokFileSystemUtil.load_resources(STRATEGY_SCRIPTS_PATH, "Script"):
 		if not resource is Script:
 			continue
 		

--- a/addons/locker/scripts/util/file_system_util.gd
+++ b/addons/locker/scripts/util/file_system_util.gd
@@ -428,13 +428,25 @@ static func parse_json_from_string(
 	return json.data
 
 ## The [method load_resources] method is a quick way to load all [Resource]s
-## located in a specific [param directory_path].
-static func load_resources(directory_path: String) -> Array[Resource]:
+static func load_resources(
+	directory_path: String,
+	resource_type: String = ""
+) -> Array[Resource]:
 	var resources: Array[Resource] = []
 	
 	var resource_names: PackedStringArray = get_file_names(directory_path)
 	
+	var formats: PackedStringArray = []
+	
+	if resource_type != "":
+		formats = ResourceLoader.get_recognized_extensions_for_type(resource_type)
+	
 	for resource_name: String in resource_names:
+		var resource_format: String = get_file_format(resource_name)
+		
+		if not LokUtil.filter_value(formats, resource_format):
+			continue
+		
 		var resource_path: String = directory_path.path_join(resource_name)
 		
 		resources.append(load(resource_path))

--- a/addons/locker/scripts/util/file_system_util.gd
+++ b/addons/locker/scripts/util/file_system_util.gd
@@ -428,6 +428,15 @@ static func parse_json_from_string(
 	return json.data
 
 ## The [method load_resources] method is a quick way to load all [Resource]s
+## located in a specific [param directory_path]. [br]
+## Optionally, a [param resource_type] [String] can be passed to filter
+## what types of [Resource]s should be loaded or to prevent unknown
+## file types from being loaded. [br]
+## As an example, if a [code]"Script"[/code] [String] is passed in the
+## [param resource_type] parameter, only files with formats that can represent
+## [Script]s are loaded. [br]
+## What formats can represent what [Resource] types are dictated by the
+## [method ResourceLoader.get_recognized_extensions_for_type] method.
 static func load_resources(
 	directory_path: String,
 	resource_type: String = ""

--- a/test/unit/util/test_file_system_util/test_file_system_util.gd
+++ b/test/unit/util/test_file_system_util/test_file_system_util.gd
@@ -1,0 +1,47 @@
+
+extends GutTest
+
+const TEST_FOLDER_PATH: String = "res://test/test_folder/"
+
+var resources: Dictionary = {}
+
+func before_all() -> void:
+	LokFileSystemUtil.create_directory_if_not_exists(TEST_FOLDER_PATH)
+	
+	var resource_names: Array[String] = [
+		"script1.gd", "script1.gd.uid", "script2.gd", "script2.gd.uid"
+	]
+	
+	for resource_name: String in resource_names:
+		var resource_path: String = TEST_FOLDER_PATH.path_join(resource_name)
+		
+		LokFileSystemUtil.create_file_if_not_exists(resource_path)
+		
+		resources[resource_name] = load(resource_path)
+
+func after_all() -> void:
+	LokFileSystemUtil.remove_directory_recursive_if_exists(TEST_FOLDER_PATH)
+	queue_free()
+
+#region Method load_resources
+
+func test_load_resources_loads_all_files_in_folder() -> void:
+	var result: Array[Resource] = LokFileSystemUtil.load_resources(
+		TEST_FOLDER_PATH
+	)
+	
+	assert_eq(result, resources.values(), "Resources didn't match expected")
+
+func test_load_resources_loads_all_files_that_match_type() -> void:
+	var result: Array[Resource] = LokFileSystemUtil.load_resources(
+		TEST_FOLDER_PATH, "Script"
+	)
+	
+	var expected: Array[Resource] = [
+		resources["script1.gd"],
+		resources["script2.gd"]
+	]
+	
+	assert_eq(result, expected, "Resources didn't match expected")
+
+#endregion


### PR DESCRIPTION
This `Pull Request` brings small modifications to how the Locker Plugin searches for default strategies to load in order to avoid error messages when trying to load files with formats unknown by the Godot `ResourceLoader`.

fixes #12 