### PR TITLE
Made the saving and loading await data gathering and distribution

### DIFF
--- a/addons/locker/plugin.cfg
+++ b/addons/locker/plugin.cfg
@@ -3,5 +3,5 @@
 name="Locker"
 description="Locker is a framework that provides a quick and scalable way to save and load data using Dictionaries and, optionally, encryption."
 author="Nadjiel"
-version="1.0.0"
+version="1.1.0"
 script="locker.gd"

--- a/addons/locker/scripts/storage_accessor/storage_accessor.gd
+++ b/addons/locker/scripts/storage_accessor/storage_accessor.gd
@@ -393,7 +393,7 @@ func consume_data(data: Dictionary) -> void:
 	if not is_active():
 		return
 	
-	_version._consume_data(data, _get_dependencies())
+	await _version._consume_data(data, _get_dependencies())
 
 ## The [method _find_version] method looks through all the
 ## [member versions] and returns the one that has same

--- a/addons/locker/scripts/storage_accessor/storage_accessor.gd
+++ b/addons/locker/scripts/storage_accessor/storage_accessor.gd
@@ -381,7 +381,7 @@ func retrieve_data() -> Dictionary:
 	if not is_active():
 		return {}
 	
-	return _version._retrieve_data(_get_dependencies())
+	return await _version._retrieve_data(_get_dependencies())
 
 ## The [method consume_data] method uses the
 ## [method LokStorageAccessorVersion._consume_data]

--- a/addons/locker/scripts/storage_manager/global_storage_manager.gd
+++ b/addons/locker/scripts/storage_manager/global_storage_manager.gd
@@ -332,7 +332,7 @@ func load_data(
 		version_numbers
 	)
 	
-	distribute_result(result, included_accessors)
+	await distribute_result(result, included_accessors)
 	
 	loading_finished.emit(result)
 	

--- a/addons/locker/scripts/storage_manager/global_storage_manager.gd
+++ b/addons/locker/scripts/storage_manager/global_storage_manager.gd
@@ -290,9 +290,9 @@ func save_data(
 	var file_path: String = _get_file_path(file_id)
 	var file_format: String = save_files_format
 	
-	var data: Dictionary = await gather_data(included_accessors, version_number)
-	
 	saving_started.emit()
+	
+	var data: Dictionary = await gather_data(included_accessors, version_number)
 	
 	var result: Dictionary = await _access_executor.request_saving(
 		file_path, file_format, data, replace

--- a/addons/locker/scripts/storage_manager/global_storage_manager.gd
+++ b/addons/locker/scripts/storage_manager/global_storage_manager.gd
@@ -261,7 +261,7 @@ func distribute_result(
 		var accessor_version: String = accessor_data.get("version", "")
 		
 		accessor.set_version_number(accessor_version)
-		accessor.consume_data(accessor_result.duplicate(true))
+		await accessor.consume_data(accessor_result.duplicate(true))
 
 ## The [method get_saved_files_ids] method returns an [Array] of [String]s
 ## with the ids of all files saved in the [member saves_directory].

--- a/addons/locker/scripts/storage_manager/global_storage_manager.gd
+++ b/addons/locker/scripts/storage_manager/global_storage_manager.gd
@@ -151,7 +151,7 @@ func collect_data(
 	accessor.set_version_number(version_number)
 	
 	var accessor_version: String = accessor.get_version_number()
-	var accessor_data: Dictionary = accessor.retrieve_data()
+	var accessor_data: Dictionary = await accessor.retrieve_data()
 	
 	if accessor_data.is_empty():
 		return {}
@@ -203,7 +203,7 @@ func gather_data(
 		if not LokUtil.filter_value(included_accessors, accessor):
 			continue
 		
-		var accessor_data: Dictionary = collect_data(accessor, version_number)
+		var accessor_data: Dictionary = await collect_data(accessor, version_number)
 		
 		if accessor_data.is_empty():
 			continue
@@ -290,7 +290,7 @@ func save_data(
 	var file_path: String = _get_file_path(file_id)
 	var file_format: String = save_files_format
 	
-	var data: Dictionary = gather_data(included_accessors, version_number)
+	var data: Dictionary = await gather_data(included_accessors, version_number)
 	
 	saving_started.emit()
 	

--- a/test/unit/storage_accessor/test_storage_accessor/test_storage_accessor.gd
+++ b/test/unit/storage_accessor/test_storage_accessor/test_storage_accessor.gd
@@ -336,7 +336,7 @@ func test_retrieve_data_awaits_async_versions() -> void:
 	assert_eq(
 		await accessor.retrieve_data(),
 		expected,
-		"Dependencies weren't passed"
+		"Data retrieval wasn't awaited"
 	)
 
 #endregion
@@ -377,5 +377,28 @@ func test_consume_data_passes_args_to_version() -> void:
 	accessor.consume_data(data)
 	
 	assert_called(version, "_consume_data", [ data, deps ])
+
+func test_consume_data_awaits_async_versions() -> void:
+	var version: LokStorageAccessorVersion = DoubledStorageAccessorVersion.new()
+	
+	var result: Dictionary = {}
+	var expected: Dictionary = { "awaited": true }
+	
+	stub(version._consume_data).to_call(
+		func(_res: Dictionary, _deps: Dictionary) -> void:
+			await get_tree().create_timer(0.01).timeout
+			
+			result["awaited"] = true
+	)
+	
+	accessor.versions = [ version ]
+	
+	await accessor.consume_data({})
+	
+	assert_eq(
+		result,
+		expected,
+		"Data consumption wasn't awaited"
+	)
 
 #endregion

--- a/test/unit/storage_accessor/test_storage_accessor/test_storage_accessor.gd
+++ b/test/unit/storage_accessor/test_storage_accessor/test_storage_accessor.gd
@@ -283,7 +283,7 @@ func test_remove_data_cancels_if_not_active() -> void:
 #region Method retrieve_data
 
 func test_retrieve_data_cancels_without_version() -> void:
-	assert_eq(accessor.retrieve_data(), {}, "Retrieval didn't cancel")
+	assert_eq(await accessor.retrieve_data(), {}, "Retrieval didn't cancel")
 
 func test_retrieve_data_cancels_if_inactive() -> void:
 	var version := LokStorageAccessorVersion.create("1.0.0")
@@ -291,7 +291,7 @@ func test_retrieve_data_cancels_if_inactive() -> void:
 	accessor.versions = [ version ]
 	accessor.active = false
 	
-	assert_eq(accessor.retrieve_data(), {}, "Retrieval didn't cancel")
+	assert_eq(await accessor.retrieve_data(), {}, "Retrieval didn't cancel")
 
 func test_retrieve_data_consults_version() -> void:
 	var version: LokStorageAccessorVersion = DoubledStorageAccessorVersion.new()
@@ -302,7 +302,7 @@ func test_retrieve_data_consults_version() -> void:
 	
 	accessor.versions = [ version ]
 	
-	assert_eq(accessor.retrieve_data(), expected, "Return wasn't expected")
+	assert_eq(await accessor.retrieve_data(), expected, "Return wasn't expected")
 
 func test_retrieve_data_passes_dependencies_to_version() -> void:
 	var version: LokStorageAccessorVersion = DoubledStorageAccessorVersion.new()
@@ -317,7 +317,27 @@ func test_retrieve_data_passes_dependencies_to_version() -> void:
 	accessor.versions = [ version ]
 	accessor.dependency_paths = { &"dep": dep_path }
 	
-	assert_eq(accessor.retrieve_data(), expected, "Dependencies weren't passed")
+	assert_eq(await accessor.retrieve_data(), expected, "Dependencies weren't passed")
+
+func test_retrieve_data_awaits_async_versions() -> void:
+	var version: LokStorageAccessorVersion = DoubledStorageAccessorVersion.new()
+	
+	var expected: Dictionary = { "success": true }
+	
+	stub(version._retrieve_data).to_call(
+		func(_deps: Dictionary) -> Dictionary:
+			await get_tree().create_timer(0.01).timeout
+			
+			return expected
+	)
+	
+	accessor.versions = [ version ]
+	
+	assert_eq(
+		await accessor.retrieve_data(),
+		expected,
+		"Dependencies weren't passed"
+	)
 
 #endregion
 

--- a/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
+++ b/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
@@ -305,7 +305,7 @@ func test_gather_data_awaits_data_retrieval() -> void:
 	
 	var result: Dictionary = await manager.gather_data()
 	
-	assert_eq(result, expected, "Data collection wasn't awaited")
+	assert_eq(result, expected, "Data gathering wasn't awaited")
 
 #endregion
 
@@ -373,6 +373,25 @@ func test_distribute_result_sends_according_to_ids() -> void:
 	
 	assert_called(accessor1, "consume_data", [ accessor1_data ])
 	assert_called(accessor2, "consume_data", [ accessor2_data ])
+
+func test_distribute_result_awaits_data_consumption() -> void:
+	var result: Dictionary = {}
+	var expected: Dictionary = { "consumed": true }
+	
+	var accessor: LokStorageAccessor = DoubledStorageAccessor.new()
+	
+	stub(accessor.consume_data).to_call(
+		func(_data: Dictionary) -> void:
+			await get_tree().create_timer(0.01).timeout
+			
+			result["consumed"] = true
+	)
+	
+	manager.accessors = [ accessor ]
+	
+	await manager.distribute_result({})
+	
+	assert_eq(result, expected, "Data distribution wasn't awaited")
 
 #endregion
 

--- a/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
+++ b/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
@@ -280,6 +280,33 @@ func test_gather_data_ignores_accessors_without_data() -> void:
 	
 	assert_eq(result, {}, "Data obtained")
 
+func test_gather_data_awaits_data_retrieval() -> void:
+	var data: Dictionary = { "retrieved": true }
+	
+	var accessor: LokStorageAccessor = DoubledStorageAccessor.new()
+	
+	accessor.id = "accessor"
+	accessor.partition = "partition"
+	
+	stub(accessor.retrieve_data).to_call(
+		func() -> Dictionary:
+			await get_tree().create_timer(0.01).timeout
+			
+			return data
+	)
+	
+	var expected: Dictionary = {
+		"partition": {
+			"accessor": { "retrieved": true }
+		}
+	}
+	
+	manager.accessors = [ accessor ]
+	
+	var result: Dictionary = await manager.gather_data()
+	
+	assert_eq(result, expected, "Data collection wasn't awaited")
+
 #endregion
 
 #region Method distribute_result

--- a/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
+++ b/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
@@ -417,7 +417,7 @@ func test_save_data_passes_to_executor() -> void:
 	
 	assert_called(manager._access_executor, "request_saving")
 
-func test_save_data_awaits_retrieval() -> void:
+func test_save_data_awaits_gathering() -> void:
 	manager._access_executor = DoubledAccessExecutor.new()
 	
 	var result: Dictionary = {}
@@ -467,6 +467,26 @@ func test_load_data_passes_to_executor() -> void:
 	manager.load_data("", [], [], [])
 	
 	assert_called(manager._access_executor, "request_loading")
+
+func test_load_data_awaits_distribution() -> void:
+	manager._access_executor = DoubledAccessExecutor.new()
+	
+	var result: Dictionary = {}
+	var expected: Dictionary = { "distributed": true }
+	
+	stub(manager.distribute_result).to_call(
+		func(
+			_result: Dictionary,
+			_accessors: Array[LokStorageAccessor] = []
+		) -> void:
+			await get_tree().create_timer(0.01).timeout
+			
+			result["distributed"] = true
+	)
+	
+	await manager.load_data("", [], [], [])
+	
+	assert_eq(result, expected, "Distribition wasn't awaited")
 
 func test_save_data_emits_loading_started() -> void:
 	watch_signals(manager)

--- a/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
+++ b/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
@@ -80,7 +80,7 @@ func test_collect_data_returns_empty_dict() -> void:
 	
 	assert_eq(await manager.collect_data(null, ""), expected, "Unexpected result")
 
-func test_collect_data_returns_sets_version_passed() -> void:
+func test_collect_data_sets_version_passed() -> void:
 	var expected: String = "2.0.0"
 	
 	var accessor: LokStorageAccessor = DoubledStorageAccessor.new()
@@ -114,6 +114,21 @@ func test_collect_data_obtains_data_with_version() -> void:
 	var result: Dictionary = await manager.collect_data(accessor, "1.0.0")
 	
 	assert_eq(result, expected, "Unexpected result")
+
+func test_collect_data_awaits_data_retrieval() -> void:
+	var expected: Dictionary = { "retrieved": true }
+	
+	var accessor: LokStorageAccessor = DoubledStorageAccessor.new()
+	stub(accessor.retrieve_data).to_call(
+		func() -> Dictionary:
+			await get_tree().create_timer(0.01).timeout
+			
+			return expected
+	)
+	
+	var result: Dictionary = await manager.collect_data(accessor)
+	
+	assert_eq(result, expected, "Data collection wasn't awaited")
 
 #endregion
 

--- a/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
+++ b/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
@@ -78,7 +78,7 @@ func test_get_file_path_returns_path_based_on_id() -> void:
 func test_collect_data_returns_empty_dict() -> void:
 	var expected: Dictionary = {}
 	
-	assert_eq(manager.collect_data(null, ""), expected, "Unexpected result")
+	assert_eq(await manager.collect_data(null, ""), expected, "Unexpected result")
 
 func test_collect_data_returns_sets_version_passed() -> void:
 	var expected: String = "2.0.0"
@@ -97,7 +97,7 @@ func test_collect_data_obtains_data_without_version() -> void:
 	var accessor: LokStorageAccessor = DoubledStorageAccessor.new()
 	stub(accessor.retrieve_data).to_return(expected.duplicate())
 	
-	var result: Dictionary = manager.collect_data(accessor, "1.0.0")
+	var result: Dictionary = await manager.collect_data(accessor, "1.0.0")
 	
 	assert_eq(result, expected, "Unexpected result")
 
@@ -111,7 +111,7 @@ func test_collect_data_obtains_data_with_version() -> void:
 	
 	expected["version"] = "1.0.0"
 	
-	var result: Dictionary = manager.collect_data(accessor, "1.0.0")
+	var result: Dictionary = await manager.collect_data(accessor, "1.0.0")
 	
 	assert_eq(result, expected, "Unexpected result")
 
@@ -123,7 +123,7 @@ func test_gather_data_ignores_unidentified_accessors() -> void:
 	var accessor: LokStorageAccessor = DoubledStorageAccessor.new()
 	stub(accessor.retrieve_data).to_return({ "accessor": true })
 	
-	var result: Dictionary = manager.gather_data()
+	var result: Dictionary = await manager.gather_data()
 	
 	assert_eq(result, {}, "Data obtained")
 
@@ -144,7 +144,7 @@ func test_gather_data_includes_identified_accessors() -> void:
 		}
 	}
 	
-	var result: Dictionary = manager.gather_data([], "1.0.0")
+	var result: Dictionary = await manager.gather_data([], "1.0.0")
 	
 	assert_eq(result, expected, "Data obtained")
 
@@ -165,7 +165,7 @@ func test_gather_data_includes_versions() -> void:
 		}
 	}
 	
-	var result: Dictionary = manager.gather_data([], "1.0.0")
+	var result: Dictionary = await manager.gather_data([], "1.0.0")
 	
 	assert_eq(result, expected, "Data obtained")
 
@@ -194,7 +194,7 @@ func test_gather_data_gets_from_multiple_accessors() -> void:
 		}
 	}
 	
-	var result: Dictionary = manager.gather_data([], "1.0.0")
+	var result: Dictionary = await manager.gather_data([], "1.0.0")
 	
 	assert_eq(result, expected, "Data obtained")
 
@@ -222,7 +222,7 @@ func test_gather_data_filters_accessors() -> void:
 		}
 	}
 	
-	var result: Dictionary = manager.gather_data([ accessor1 ], "1.0.0")
+	var result: Dictionary = await manager.gather_data([ accessor1 ], "1.0.0")
 	
 	assert_eq(result, expected, "Data obtained")
 
@@ -253,7 +253,7 @@ func test_gather_data_separates_partitions() -> void:
 		}
 	}
 	
-	var result: Dictionary = manager.gather_data([], "1.0.0")
+	var result: Dictionary = await manager.gather_data([], "1.0.0")
 	
 	assert_eq(result, expected, "Data obtained")
 
@@ -261,7 +261,7 @@ func test_gather_data_ignores_accessors_without_data() -> void:
 	var accessor: LokStorageAccessor = DoubledStorageAccessor.new()
 	stub(accessor.retrieve_data).to_return({})
 	
-	var result: Dictionary = manager.gather_data()
+	var result: Dictionary = await manager.gather_data()
 	
 	assert_eq(result, {}, "Data obtained")
 


### PR DESCRIPTION
## Overview
This PR brings a slight modification to how the data saving and loading behave when it comes to handling asynchronous data gathering and distribution.

## Related Issues
closes #27 

## Checklist
- [X] This code follows the project's coding style.
- [X] I have tested my changes in Godot 4.3.
- [X] I have updated the documentation (if applicable).
- [X] I have added tests (if applicable).
- [X] This PR does not introduce new warnings or errors.

## What was changed
The change introduced with this PR is that before the data saving and loading realized through the [`LokGlobalStorageManager`](https://github.com/locker-godot/locker/blob/d8e545e9faace424b80bdbb20c845aa014c8552b/addons/locker/scripts/storage_manager/global_storage_manager.gd) wouldn't wait for asynchronous data gathering and distribution, which made it hard to implement cascade loadings, for example, as described in the related issue #27.
As of this PR, those methods now await asynchronous gathering and distribution of data, which allows for that use case.

## How to Test
Run GUT, which should include the new unit tests added together with this PR.
