### PR TITLE
Fixed EditorPlugin dependency on GlobalStorageManager

### DIFF
--- a/.changeset/lovely-loops-cheat.md
+++ b/.changeset/lovely-loops-cheat.md
@@ -1,0 +1,5 @@
+---
+"locker": patch
+---
+
+Fixed bug in exported builds where GlobalStorageManager couldn't be resolved thanks to reference to non existent (on builds) LockerPlugin.

--- a/addons/locker/locker.gd
+++ b/addons/locker/locker.gd
@@ -1,14 +1,14 @@
 @icon("res://addons/locker/icons/locker_plugin.svg")
 @tool
-## The [LockerPlugin] class is the manager of the Locker Plugin's settings.
+## The [LockerPlugin] class is the manager of the Locker Plugin's
+## editor features.
 ## 
-## This class is responsible for managing the access of the Plugin
-## settings through the use of the [ProjectSettings]. [br]
-## The settings of this Plugin stay available in the
-## [code]addons/locker[/code] path of the [ProjectSettings]. [br]
-## They only become available if the [LockerPlugin] is active, though. [br]
+## This class is responsible for managing the access of the settings
+## of this Plugin through the use of the [LokSettingsManager] class.[br]
+## The settings of this Plugin only become available while the
+## [LockerPlugin] is active, though.[br]
 ## When active, this Plugin also registers the [LokGlobalStorageManager]
-## as an autoload singleton. [br]
+## as an autoload singleton.[br]
 ## [br]
 ## [b]Version[/b]: 1.0.0[br]
 ## [b]Author[/b]: [url]github.com/nadjiel[/url]
@@ -16,11 +16,6 @@ class_name LockerPlugin
 extends EditorPlugin
 
 #region Constants
-
-## The [constant CONFIG_PATH] constant stores the path where the
-## [LockerPlugin]'s configurations should be stored, so that they can be
-## persisted even when the Plugin is deactivated and activated.
-const CONFIG_PATH: String = "res://addons/locker/config.cfg"
 
 ## The [constant AUTOLOAD_NAME] constant stores the name that should be
 ## given to the [LockerPlugin]'s autoload, when registered.
@@ -30,262 +25,6 @@ const AUTOLOAD_NAME := "LokGlobalStorageManager"
 ## the [LokGlobalStorageManager] so that this [LockerPlugin] can register it
 ## as an autoload when it is activated.
 const AUTOLOAD_PATH := "res://addons/locker/scripts/storage_manager/global_storage_manager.gd"
-
-## The [constant STRATEGY_SCRIPTS_PATH] constant stores the path to where the
-## scripts of [LokAccessStrategy]s are located. [br]
-## It's the [LokAccessStrategy]s declared in that folder that are exposed
-## to be selectable in the [ProjectSettings] as [LokAccessStrategy]s to be
-## used by this plugin.
-const STRATEGY_SCRIPTS_PATH := "res://addons/locker/scripts/access_strategy/default_strategies/"
-
-#endregion
-
-#region Settings
-
-## The [member _strategy_scripts] property stores references to the [Script]s
-## of the [LokAccessStrategy]s that the [LockerPlugin] knows thanks
-## to the path in the [constant STRATEGY_SCRIPTS_PATH] constant.
-static var _strategy_scripts: Array[Script] = _load_strategy_scripts():
-	set = _set_strategy_scripts,
-	get = _get_strategy_scripts
-
-## The [member _plugin_settings] property stores a [Dictionary] that describes
-## all the settings that should be appended to the [ProjectSettings] when
-## the [LockerPlugin] is activated, so that they can be easily edited through
-## the editor. [br]
-## Each key of this [Dictionary] points to the setting path in the
-## [ProjectSettings] and each value describes information about the setting.
-## [br]
-## The structure of this property is as follows:
-## [codeblock]
-## {
-##   "setting_1_path": {
-##     "default_value": <Variant>,
-##     "current_value": <Variant>,
-##     "is_basic": <bool>,
-##     "property_info": {
-##       "name": "setting_1_path",
-##       "type": <@GlobalScope.Variant.Type>,
-##       "hint": <@GlobalScope.PropertyHint>,
-##       "hint_string": <String>
-##     },
-##     "config_section": <String>,
-##   },
-##   "setting_n_path": { ... }
-## }
-## [/codeblock]
-## The settings defined in this property are the following: [br]
-## - [code]"addons/locker/saves_directory"[/code]: This setting defines the
-## default directory where the [LokGlobalStorageManager] should save and load
-## the game data. [br]
-## - [code]"addons/locker/save_files_prefix"[/code]: This setting defines the
-## default prefix that should be given to the save files by the
-## [LokGlobalStorageManager]. [br]
-## - [code]"addons/locker/save_files_format"[/code]: This setting defines the
-## default file format that should be given to the save files by the
-## [LokGlobalStorageManager]. [br]
-## - [code]"addons/locker/save_versions"[/code]: This setting defines if,
-## by default, the [LokGlobalStorageManager] should store the save versions
-## when saving. [br]
-## - [code]"addons/locker/access_strategy"[/code]: This setting stores a
-## [String] that represents what [LokAccessStrategy] the
-## [LokGlobalStorageManager] should use to save and load data. To convert
-## from this [String] representation to an actual [LokAccessStrategy] instance,
-## the [method _string_to_strategy] method can be used. [br]
-## - [code]"addons/locker/encrypted_strategy/password"[/code]: This setting
-## stores the default password that should be used by the
-## [LokGlobalStorageManager]'s strategy, if it is the
-## [LokEncryptedAccessStrategy].
-static var _plugin_settings := {
-	"addons/locker/saves_directory": {
-		"default_value": "user://saves/",
-		"current_value": "user://saves/",
-		"is_basic": true,
-		"property_info": {
-			"name": "addons/locker/saves_directory",
-			"type": TYPE_STRING,
-			"hint": PROPERTY_HINT_DIR
-		},
-		"config_section": "General"
-	},
-	"addons/locker/save_files_prefix": {
-		"default_value": "file",
-		"current_value": "file",
-		"is_basic": true,
-		"property_info": {
-			"name": "addons/locker/save_files_prefix",
-			"type": TYPE_STRING,
-			"hint": PROPERTY_HINT_NONE
-		},
-		"config_section": "General"
-	},
-	"addons/locker/save_files_format": {
-		"default_value": "sav",
-		"current_value": "sav",
-		"is_basic": true,
-		"property_info": {
-			"name": "addons/locker/save_files_format",
-			"type": TYPE_STRING,
-			"hint": PROPERTY_HINT_NONE
-		},
-		"config_section": "General"
-	},
-	"addons/locker/save_versions": {
-		"default_value": true,
-		"current_value": true,
-		"is_basic": true,
-		"property_info": {
-			"name": "addons/locker/save_versions",
-			"type": TYPE_BOOL,
-			"hint": PROPERTY_HINT_NONE
-		},
-		"config_section": "General"
-	},
-	"addons/locker/access_strategy": {
-		"default_value": "Encrypted",
-		"current_value": "Encrypted",
-		"is_basic": true,
-		"property_info": {
-			"name": "addons/locker/access_strategy",
-			"type": TYPE_STRING,
-			"hint": PROPERTY_HINT_ENUM,
-			"hint_string": "JSON,Encrypted"
-		},
-		"config_section": "General"
-	},
-	"addons/locker/encrypted_strategy/password": {
-		"default_value": "",
-		"current_value": "",
-		"is_basic": true,
-		"property_info": {
-			"name": "addons/locker/encrypted_strategy/password",
-			"type": TYPE_STRING,
-			"hint": PROPERTY_HINT_NONE
-		},
-		"config_section": "EncryptedStrategy"
-	}
-}:
-	set = _set_plugin_settings,
-	get = _get_plugin_settings
-
-#endregion
-
-#region Settings Setters & Getters
-
-## The [method set_setting_saves_directory] method is a shortcut to
-## defining the [code]"addons/locker/saves_directory"[/code] setting
-## in the [ProjectSettings] to the value of the passed [param path].
-static func set_setting_saves_directory(path: String) -> void:
-	ProjectSettings.set_setting("addons/locker/saves_directory", path)
-
-## The [method get_setting_saves_directory] method is a getter to facilitate
-## obtaining the [code]"addons/locker/saves_directory"[/code] setting
-## from the [ProjectSettings].
-static func get_setting_saves_directory() -> String:
-	return ProjectSettings.get_setting(
-		"addons/locker/saves_directory",
-		_plugin_settings["addons/locker/saves_directory"]["default_value"]
-	)
-
-## The [method set_setting_save_files_prefix] method is a shortcut to
-## defining the [code]"addons/locker/save_files_prefix"[/code] setting
-## in the [ProjectSettings] to the value of the passed [param prefix].
-static func set_setting_save_files_prefix(prefix: String) -> void:
-	ProjectSettings.set_setting("addons/locker/save_files_prefix", prefix)
-
-## The [method get_setting_save_files_prefix] method is a getter to facilitate
-## obtaining the [code]"addons/locker/save_files_prefix"[/code] setting
-## from the [ProjectSettings].
-static func get_setting_save_files_prefix() -> String:
-	return ProjectSettings.get_setting(
-		"addons/locker/save_files_prefix",
-		_plugin_settings["addons/locker/save_files_prefix"]["default_value"]
-	)
-
-## The [method set_setting_save_files_format] method is a shortcut to
-## defining the [code]"addons/locker/save_files_format"[/code] setting
-## in the [ProjectSettings] to the value of the passed [param format].
-static func set_setting_save_files_format(format: String) -> void:
-	ProjectSettings.set_setting("addons/locker/save_files_format", format)
-
-## The [method get_setting_save_files_format] method is a getter to facilitate
-## obtaining the [code]"addons/locker/save_files_format"[/code] setting
-## from the [ProjectSettings].
-static func get_setting_save_files_format() -> String:
-	return ProjectSettings.get_setting(
-		"addons/locker/save_files_format",
-		_plugin_settings["addons/locker/save_files_format"]["default_value"]
-	)
-
-## The [method set_setting_save_versions] method is a shortcut to
-## defining the [code]"addons/locker/save_versions"[/code] setting
-## in the [ProjectSettings] to the value of the passed [param state].
-static func set_setting_save_versions(state: bool) -> void:
-	ProjectSettings.set_setting("addons/locker/save_versions", state)
-
-## The [method get_setting_save_versions] method is a getter to facilitate
-## obtaining the [code]"addons/locker/save_versions"[/code] setting
-## from the [ProjectSettings].
-static func get_setting_save_versions() -> bool:
-	return ProjectSettings.get_setting(
-		"addons/locker/save_versions",
-		_plugin_settings["addons/locker/save_versions"]["default_value"]
-	)
-
-## The [method set_setting_access_strategy] method is a shortcut to
-## defining the [code]"addons/locker/access_strategy"[/code] setting
-## in the [ProjectSettings] to the value of the passed [param strategy].
-static func set_setting_access_strategy(strategy: String) -> void:
-	ProjectSettings.set_setting("addons/locker/access_strategy", strategy)
-
-## The [method get_setting_access_strategy] method is a getter to facilitate
-## obtaining the [code]"addons/locker/access_strategy"[/code] setting
-## from the [ProjectSettings].
-static func get_setting_access_strategy() -> String:
-	return ProjectSettings.get_setting(
-		"addons/locker/access_strategy",
-		_plugin_settings["addons/locker/access_strategy"]["default_value"]
-	)
-
-## The [method get_setting_access_strategy_parsed] method is a getter to
-## facilitate obtaining the [code]"addons/locker/access_strategy"[/code]
-## setting from the [ProjectSettings] already parsed as a [LokAccessStrategy].
-static func get_setting_access_strategy_parsed() -> LokAccessStrategy:
-	return _string_to_strategy(get_setting_access_strategy())
-
-## The [method set_setting_encrypted_strategy_password] method is a shortcut to
-## defining the [code]"addons/locker/encrypted_strategy/password"[/code] setting
-## in the [ProjectSettings] to the value of the passed [param password].
-static func set_setting_encrypted_strategy_password(password: String) -> void:
-	ProjectSettings.set_setting(
-		"addons/locker/encrypted_strategy/password", password
-	)
-
-## The [method get_setting_encrypted_strategy_password] method is a getter
-## to facilitate obtaining the
-## [code]"addons/locker/encrypted_strategy/password"[/code]
-## setting from the [ProjectSettings].
-static func get_setting_encrypted_strategy_password() -> String:
-	return ProjectSettings.get_setting(
-		"addons/locker/encrypted_strategy/password",
-		_plugin_settings["addons/locker/encrypted_strategy/password"]["default_value"]
-	)
-
-#endregion
-
-#region Setters & Getters
-
-static func _set_strategy_scripts(new_scripts: Array[Script]) -> void:
-	_strategy_scripts = new_scripts
-
-static func _get_strategy_scripts() -> Array[Script]:
-	return _strategy_scripts
-
-static func _set_plugin_settings(new_settings: Dictionary) -> void:
-	_plugin_settings = new_settings
-
-static func _get_plugin_settings() -> Dictionary:
-	return _plugin_settings
 
 #endregion
 
@@ -307,229 +46,23 @@ func _enable_plugin() -> void:
 func _disable_plugin() -> void:
 	_finish_plugin()
 
-## The [method _load_strategy_scripts] method returns an [Array] of
-## [Script]s with the scripts that could be found in the path
-## pointed by the [constant STRATEGY_SCRIPTS_PATH] constant.
-static func _load_strategy_scripts() -> Array[Script]:
-	var scripts: Array[Script] = []
-	
-	for resource: Resource in LokFileSystemUtil.load_resources(STRATEGY_SCRIPTS_PATH, "Script"):
-		if not resource is Script:
-			continue
-		
-		scripts.append(resource as Script)
-	
-	return scripts
-
-## The [method _get_strategies] method returns an [Array] of
-## [LokAccessStrategy] instances got from the [Script]s in the
-## [member _strategy_scripts] property.
-static func _get_strategies() -> Array[LokAccessStrategy]:
-	var strategies: Array[LokAccessStrategy] = []
-	
-	for script: Script in _strategy_scripts:
-		var strategy: Object = script.new()
-		
-		if strategy is LokAccessStrategy:
-			strategies.append(strategy as LokAccessStrategy)
-	
-	return strategies
-
-## The [method _get_strategies_enum_string] method parses the
-## [LokAccessStrategy]s that the [LockerPlugin] knows into a [String]
-## that describes them in a way compatible with [code]hint_string[/code]s.
-static func _get_strategies_enum_string() -> String:
-	var result: String = ""
-	
-	var strategies: Array[LokAccessStrategy] = _get_strategies()
-	
-	for i: int in strategies.size():
-		var strategy: LokAccessStrategy = strategies[i]
-		
-		result += str(strategy)
-		
-		if i != strategies.size() - 1:
-			result += ","
-	
-	return result
-
-## The [method _get_default_strategy_name] method tries to get the
-## name of the [LokAccessStrategy] specified by the [param wanted_name]
-## parameter, so that name can be used in the [ProjectSettings] as the
-## default choice in the strategies enum. [br]
-## If there's no such [LokAccessStrategy] known by the [LockerPlugin], this
-## method will return any [LokAccessStrategy] name it knows, or even
-## an empty [String], if it doesn't know any [LokAccessStrategy]s.
-static func _get_default_strategy_name(wanted_name: String) -> String:
-	var result: String = ""
-	
-	var strategies: Array[LokAccessStrategy] = _get_strategies()
-	
-	for strategy: LokAccessStrategy in strategies:
-		var strategy_name: String = str(strategy)
-		
-		if strategy_name == wanted_name:
-			result = wanted_name
-			
-			return result
-	
-	if result == "" and not strategies.is_empty():
-		result = str(strategies[0])
-	
-	return result
-
-## The [method _update_available_strategies] method uses the
-## [member _strategy_scripts] to update what [LokAccessStrategy] options
-## should be shown in the [ProjectSettings] as options to choose from.
-func _update_available_strategies() -> void:
-	_strategy_scripts = _load_strategy_scripts()
-	var available_strategies: Array[LokAccessStrategy] = _get_strategies()
-	var string_of_available_strategies: String = _get_strategies_enum_string()
-	var default_strategy_string: String = _get_default_strategy_name("Encrypted")
-	
-	_plugin_settings["addons/locker/access_strategy"]["property_info"]["hint_string"] = string_of_available_strategies
-	_plugin_settings["addons/locker/access_strategy"]["default_value"] = default_strategy_string
-	_plugin_settings["addons/locker/access_strategy"]["current_value"] = default_strategy_string
-
-## The [method _string_to_strategy] method takes a [param string] and
-## returns a [LokAccessStrategy] that corresponds to that [param string]. [br]
-## If an invalid [param string] is passed, this method returns
-## [code]null[/code].
-static func _string_to_strategy(string: String) -> LokAccessStrategy:
-	var strategies: Array[LokAccessStrategy] = _get_strategies()
-	
-	for strategy: LokAccessStrategy in strategies:
-		if string == str(strategy):
-			return strategy
-	
-	return null
-
-## The [method _strategy_to_string] method takes a [param strategy] and
-## returns a [String] that represents that [param strategy] in the
-## [code]"addons/locker/access_strategy"[/code] setting of the
-## [ProjectSettings]. [br]
-## If an invalid [param strategy] is passed, this method returns
-## an empty [String].
-static func _strategy_to_string(strategy: LokAccessStrategy) -> String:
-	if strategy == null:
-		return ""
-	
-	return str(strategy)
-
-## The [method _save_settings] method takes a [param settings] [Dictionary] and
-## takes the current value of each one of them from the [ProjectSettings],
-## saving them in a [ConfigFile] in the [constant CONFIG_PATH]. [br]
-## The [param settings] parameter has to conform to the structure explained in
-## the [member _plugin_settings] description.
-func _save_settings(settings: Dictionary) -> void:
-	if settings.is_empty():
-		return
-	
-	var config := ConfigFile.new()
-	var err: Error = config.load(CONFIG_PATH)
-	
-	for setting_path: String in settings:
-		var setting_data: Dictionary = settings[setting_path]
-		var setting_section: String = setting_data["config_section"]
-		var setting_name: String = setting_path.get_slice("/locker/", 1)
-		var setting_value: Variant = ProjectSettings.get_setting(
-			setting_path, setting_data["default_value"]
-		)
-		
-		config.set_value(setting_section, setting_name, setting_value)
-	
-	config.save(CONFIG_PATH)
-
-## The [method _load_settings] method takes a [param settings] [Dictionary] and
-## loads the settings described by it from the [ConfigFile] in the
-## [constant CONFIG_PATH].
-## This method, then, sets the loaded settings in the [ProjectSettings]. [br]
-## The [param settings] parameter has to conform to the structure explained in
-## the [member _plugin_settings] description.
-func _load_settings(settings: Dictionary) -> void:
-	var config := ConfigFile.new()
-	var err: Error = config.load(CONFIG_PATH)
-	
-	if err != OK:
-		return
-	
-	for setting_path: String in settings:
-		var setting_data: Dictionary = settings[setting_path]
-		var setting_section: String = setting_data["config_section"]
-		var setting_name: String = setting_path.get_slice("/locker/", 1)
-		var default_value: Variant = setting_data["default_value"]
-		
-		var new_value: Variant = config.get_value(
-			setting_section, setting_name, default_value
-		)
-		
-		if new_value != setting_data["current_value"]:
-			setting_data["current_value"] = new_value
-		
-		ProjectSettings.set_setting(setting_path, new_value)
-
-## The [method _get_changed_settings] method takes a [param settings]
-## [Dictionary] and looks for settings that had their values changed. [br]
-## When found, their values are updated and they are returned.
-## The [param settings] parameter as well as the returned [Dictionary]
-## conform to the structure explained in the [member _plugin_settings]
-## description.
-func _get_changed_settings(settings: Dictionary) -> Dictionary:
-	var settings_changed: Dictionary = {}
-	
-	for setting_path: String in settings.keys():
-		var setting_data: Dictionary = settings[setting_path]
-		var default_value: Variant = setting_data["default_value"]
-		var new_value: Variant = ProjectSettings.get_setting(
-			setting_path, default_value
-		)
-		
-		if new_value != setting_data["current_value"]:
-			settings_changed[setting_path] = setting_data
-			
-			setting_data["current_value"] = new_value
-	
-	return settings_changed
-
-## The [method _add_settings] method takes a [param settings]
-## [Dictionary] and saves each of its settings in the [ProjectSettings]. [br]
-## The [param settings] parameter must conform to the structure explained
-## in the [member _plugin_settings] description.
-func _add_settings(settings: Dictionary) -> void:
-	for setting_path: String in settings.keys():
-		var setting: Dictionary = settings[setting_path]
-		
-		ProjectSettings.set_setting(setting_path, setting["default_value"])
-		ProjectSettings.set_initial_value(setting_path, setting["default_value"])
-		ProjectSettings.set_as_basic(setting_path, setting["is_basic"])
-		ProjectSettings.add_property_info(setting["property_info"])
-
-## The [method _remove_settings] method takes a [param settings]
-## [Dictionary] and removes each of its settings from the [ProjectSettings].
-## [br]
-## The [param settings] parameter must conform to the structure explained
-## in the [member _plugin_settings] description.
-func _remove_settings(settings: Dictionary) -> void:
-	for setting_path: String in settings.keys():
-		var setting: Dictionary = settings[setting_path]
-		
-		ProjectSettings.set_setting(setting_path, null)
-
 ## The [method _start_plugin] method registers the singleton needed by the
-## [LockerPlugin] as an autoload, so it isn't needed to do that manually. [br]
+## [LockerPlugin] as an autoload, so it isn't needed to do that manually.[br]
 ## This method also updates and registers the settings of this plugin in the
 ## [ProjectSettings], making sure to load any settings used before deactivating
-## this plugin. [br]
+## this plugin.[br]
 ## When doing that, this method makes it so arbitrary [LokAccessStratey]s
-## registered in the [member access_strategy_paths] property are also
-## registered in the [ProjectSettings] so that they can be easily selected. [br]
+## saved in the [member LokSettingsManager.STRATEGY_SCRIPTS_PATH] are also
+## made available in the [ProjectSettings] so that they can be easily selected.
+## [br]
 ## Finally, this method makes sure that whenever a setting from this Plugin
-## is altered, it is saved in the [ConfigFile] in the [constant CONFIG_PATH].
+## is altered, it is saved in the [ConfigFile] in the
+## [constant LokSettingsManager.CONFIG_PATH].
 func _start_plugin() -> void:
-	_update_available_strategies()
+	LokSettingsManager.update_available_strategies()
 	add_autoload_singleton(AUTOLOAD_NAME, AUTOLOAD_PATH)
-	_add_settings(_plugin_settings)
-	_load_settings(_plugin_settings)
+	LokSettingsManager.add_settings()
+	LokSettingsManager.load_settings()
 	
 	LokUtil.check_and_connect_signal(
 		ProjectSettings, &"settings_changed", _on_project_settings_changed
@@ -537,12 +70,12 @@ func _start_plugin() -> void:
 
 ## The [method _finish_plugin] method unregisters the singleton needed by the
 ## [LockerPlugin] from the autoloads, so it doesn't stay there without the
-## Plugin being active. [br]
+## Plugin being active.[br]
 ## This method also unregisters the settings of this plugin from the
 ## [ProjectSettings].
 func _finish_plugin() -> void:
 	remove_autoload_singleton(AUTOLOAD_NAME)
-	_remove_settings(_plugin_settings)
+	LokSettingsManager.remove_settings()
 	
 	LokUtil.check_and_disconnect_signal(
 		ProjectSettings, &"settings_changed", _on_project_settings_changed
@@ -550,8 +83,8 @@ func _finish_plugin() -> void:
 
 # Updates config.cfg file to store changed settings
 func _on_project_settings_changed() -> void:
-	var changed_settings: Dictionary = _get_changed_settings(_plugin_settings)
+	var changed_settings: Dictionary = LokSettingsManager.get_changed_settings()
 	
-	_save_settings(changed_settings)
+	LokSettingsManager.save_settings(changed_settings)
 
 #endregion

--- a/addons/locker/scripts/settings/settings_manager.gd
+++ b/addons/locker/scripts/settings/settings_manager.gd
@@ -1,0 +1,491 @@
+@tool
+@icon("res://addons/locker/icons/util.svg")
+## The [LokSettingsManager] class provides simplified ways to
+## manage the [LockerPlugin] settings.
+## 
+## This class is responsible for managing the access of the [LockerPlugin]'s
+## settings through the use of the [ProjectSettings].[br]
+## The settings of this Plugin stay available in the
+## [code]addons/locker[/code] path of the [ProjectSettings].[br]
+## With this class, the settings exposed by the [LockerPlugin] can
+## be registered, unregistered, set and get from the [ProjectSettings].[br]
+## [br]
+## [b]Version[/b]: 1.1.2 [br]
+## [b]Author[/b]: Daniel Sousa ([url]github.com/nadjiel[/url])
+class_name LokSettingsManager
+extends Node
+
+#region Constants
+
+## The [constant CONFIG_PATH] constant stores the path where the
+## [LockerPlugin]'s configurations should be stored, so that they can be
+## persisted even when the Plugin is deactivated and activated again.
+const CONFIG_PATH: String = "res://addons/locker/config.cfg"
+
+## The [constant STRATEGY_SCRIPTS_PATH] constant stores the path to where the
+## scripts of [LokAccessStrategy]s are located.[br]
+## It's the [LokAccessStrategy]s declared in that folder that are exposed
+## to be selectable in the [ProjectSettings] as [LokAccessStrategy]s to be
+## used by this plugin.
+const STRATEGY_SCRIPTS_PATH := "res://addons/locker/scripts/access_strategy/default_strategies/"
+
+#endregion
+
+#region Properties
+
+## The [member _strategy_scripts] property stores references to the [Script]s
+## of the [LokAccessStrategy]s that the [LockerPlugin] knows thanks
+## to the path in the [constant STRATEGY_SCRIPTS_PATH] constant.
+static var _strategy_scripts: Array[Script] = _load_strategy_scripts():
+	set = _set_strategy_scripts,
+	get = _get_strategy_scripts
+
+## The [member _plugin_settings] property stores a [Dictionary] that describes
+## all the settings that should be appended to the [ProjectSettings] when
+## the [LockerPlugin] is activated, so that they can be easily edited through
+## the editor.[br]
+## Each key of this [Dictionary] points to the setting path in the
+## [ProjectSettings] and each value describes information about the setting.[br]
+## The structure of this property is as follows:
+## [codeblock lang=gdscript]
+## {
+##   "setting_1_path": {
+##     "default_value": <Variant>,
+##     "current_value": <Variant>,
+##     "is_basic": <bool>,
+##     "property_info": {
+##       "name": "setting_1_path",
+##       "type": <@GlobalScope.Variant.Type>,
+##       "hint": <@GlobalScope.PropertyHint>,
+##       "hint_string": <String>
+##     },
+##     "config_section": <String>,
+##   },
+##   "setting_n_path": { ... }
+## }
+## [/codeblock]
+## The settings defined in this property are the following:[br]
+## - [code]"addons/locker/saves_directory"[/code]: This setting defines the
+## default directory where the [LokGlobalStorageManager] should save and load
+## the game data.[br]
+## - [code]"addons/locker/save_files_prefix"[/code]: This setting defines the
+## default prefix that should be given to the save files by the
+## [LokGlobalStorageManager].[br]
+## - [code]"addons/locker/save_files_format"[/code]: This setting defines the
+## default file format that should be given to the save files by the
+## [LokGlobalStorageManager].[br]
+## - [code]"addons/locker/save_versions"[/code]: This setting defines if,
+## by default, the [LokGlobalStorageManager] should store the save versions
+## when saving.[br]
+## - [code]"addons/locker/access_strategy"[/code]: This setting stores a
+## [String] that represents what [LokAccessStrategy] the
+## [LokGlobalStorageManager] should use to save and load data. To convert
+## from this [String] representation to an actual [LokAccessStrategy] instance,
+## the [method _string_to_strategy] method can be used.[br]
+## - [code]"addons/locker/encrypted_strategy/password"[/code]: This setting
+## stores the default password that should be used by the
+## [LokGlobalStorageManager]'s strategy, if it is the
+## [LokEncryptedAccessStrategy].
+static var _plugin_settings := {
+	"addons/locker/saves_directory": {
+		"default_value": "user://saves/",
+		"current_value": "user://saves/",
+		"is_basic": true,
+		"property_info": {
+			"name": "addons/locker/saves_directory",
+			"type": TYPE_STRING,
+			"hint": PROPERTY_HINT_DIR
+		},
+		"config_section": "General"
+	},
+	"addons/locker/save_files_prefix": {
+		"default_value": "file",
+		"current_value": "file",
+		"is_basic": true,
+		"property_info": {
+			"name": "addons/locker/save_files_prefix",
+			"type": TYPE_STRING,
+			"hint": PROPERTY_HINT_NONE
+		},
+		"config_section": "General"
+	},
+	"addons/locker/save_files_format": {
+		"default_value": "sav",
+		"current_value": "sav",
+		"is_basic": true,
+		"property_info": {
+			"name": "addons/locker/save_files_format",
+			"type": TYPE_STRING,
+			"hint": PROPERTY_HINT_NONE
+		},
+		"config_section": "General"
+	},
+	"addons/locker/save_versions": {
+		"default_value": true,
+		"current_value": true,
+		"is_basic": true,
+		"property_info": {
+			"name": "addons/locker/save_versions",
+			"type": TYPE_BOOL,
+			"hint": PROPERTY_HINT_NONE
+		},
+		"config_section": "General"
+	},
+	"addons/locker/access_strategy": {
+		"default_value": "Encrypted",
+		"current_value": "Encrypted",
+		"is_basic": true,
+		"property_info": {
+			"name": "addons/locker/access_strategy",
+			"type": TYPE_STRING,
+			"hint": PROPERTY_HINT_ENUM,
+			"hint_string": "JSON,Encrypted"
+		},
+		"config_section": "General"
+	},
+	"addons/locker/encrypted_strategy/password": {
+		"default_value": "",
+		"current_value": "",
+		"is_basic": true,
+		"property_info": {
+			"name": "addons/locker/encrypted_strategy/password",
+			"type": TYPE_STRING,
+			"hint": PROPERTY_HINT_NONE
+		},
+		"config_section": "EncryptedStrategy"
+	}
+}:
+	set = _set_plugin_settings,
+	get = _get_plugin_settings
+
+#endregion
+
+#region Settings Setters & Getters
+
+## The [method set_setting_saves_directory] method is a shortcut to
+## defining the [code]"addons/locker/saves_directory"[/code] setting
+## in the [ProjectSettings] to the value of the passed [param path].
+static func set_setting_saves_directory(path: String) -> void:
+	ProjectSettings.set_setting("addons/locker/saves_directory", path)
+
+## The [method get_setting_saves_directory] method is a getter to facilitate
+## obtaining the [code]"addons/locker/saves_directory"[/code] setting
+## from the [ProjectSettings].
+static func get_setting_saves_directory() -> String:
+	return ProjectSettings.get_setting(
+		"addons/locker/saves_directory",
+		_plugin_settings["addons/locker/saves_directory"]["default_value"]
+	)
+
+## The [method set_setting_save_files_prefix] method is a shortcut to
+## defining the [code]"addons/locker/save_files_prefix"[/code] setting
+## in the [ProjectSettings] to the value of the passed [param prefix].
+static func set_setting_save_files_prefix(prefix: String) -> void:
+	ProjectSettings.set_setting("addons/locker/save_files_prefix", prefix)
+
+## The [method get_setting_save_files_prefix] method is a getter to facilitate
+## obtaining the [code]"addons/locker/save_files_prefix"[/code] setting
+## from the [ProjectSettings].
+static func get_setting_save_files_prefix() -> String:
+	return ProjectSettings.get_setting(
+		"addons/locker/save_files_prefix",
+		_plugin_settings["addons/locker/save_files_prefix"]["default_value"]
+	)
+
+## The [method set_setting_save_files_format] method is a shortcut to
+## defining the [code]"addons/locker/save_files_format"[/code] setting
+## in the [ProjectSettings] to the value of the passed [param format].
+static func set_setting_save_files_format(format: String) -> void:
+	ProjectSettings.set_setting("addons/locker/save_files_format", format)
+
+## The [method get_setting_save_files_format] method is a getter to facilitate
+## obtaining the [code]"addons/locker/save_files_format"[/code] setting
+## from the [ProjectSettings].
+static func get_setting_save_files_format() -> String:
+	return ProjectSettings.get_setting(
+		"addons/locker/save_files_format",
+		_plugin_settings["addons/locker/save_files_format"]["default_value"]
+	)
+
+## The [method set_setting_save_versions] method is a shortcut to
+## defining the [code]"addons/locker/save_versions"[/code] setting
+## in the [ProjectSettings] to the value of the passed [param state].
+static func set_setting_save_versions(state: bool) -> void:
+	ProjectSettings.set_setting("addons/locker/save_versions", state)
+
+## The [method get_setting_save_versions] method is a getter to facilitate
+## obtaining the [code]"addons/locker/save_versions"[/code] setting
+## from the [ProjectSettings].
+static func get_setting_save_versions() -> bool:
+	return ProjectSettings.get_setting(
+		"addons/locker/save_versions",
+		_plugin_settings["addons/locker/save_versions"]["default_value"]
+	)
+
+## The [method set_setting_access_strategy] method is a shortcut to
+## defining the [code]"addons/locker/access_strategy"[/code] setting
+## in the [ProjectSettings] to the value of the passed [param strategy].
+static func set_setting_access_strategy(strategy: String) -> void:
+	ProjectSettings.set_setting("addons/locker/access_strategy", strategy)
+
+## The [method get_setting_access_strategy] method is a getter to facilitate
+## obtaining the [code]"addons/locker/access_strategy"[/code] setting
+## from the [ProjectSettings].
+static func get_setting_access_strategy() -> String:
+	return ProjectSettings.get_setting(
+		"addons/locker/access_strategy",
+		_plugin_settings["addons/locker/access_strategy"]["default_value"]
+	)
+
+## The [method get_setting_access_strategy_parsed] method is a getter to
+## facilitate obtaining the [code]"addons/locker/access_strategy"[/code]
+## setting from the [ProjectSettings] already parsed as a [LokAccessStrategy].
+static func get_setting_access_strategy_parsed() -> LokAccessStrategy:
+	return _string_to_strategy(get_setting_access_strategy())
+
+## The [method set_setting_encrypted_strategy_password] method is a shortcut to
+## defining the [code]"addons/locker/encrypted_strategy/password"[/code] setting
+## in the [ProjectSettings] to the value of the passed [param password].
+static func set_setting_encrypted_strategy_password(password: String) -> void:
+	ProjectSettings.set_setting(
+		"addons/locker/encrypted_strategy/password", password
+	)
+
+## The [method get_setting_encrypted_strategy_password] method is a getter
+## to facilitate obtaining the
+## [code]"addons/locker/encrypted_strategy/password"[/code]
+## setting from the [ProjectSettings].
+static func get_setting_encrypted_strategy_password() -> String:
+	return ProjectSettings.get_setting(
+		"addons/locker/encrypted_strategy/password",
+		_plugin_settings["addons/locker/encrypted_strategy/password"]["default_value"]
+	)
+
+#endregion
+
+#region Setters & Getters
+
+static func _set_strategy_scripts(new_scripts: Array[Script]) -> void:
+	_strategy_scripts = new_scripts
+
+static func _get_strategy_scripts() -> Array[Script]:
+	return _strategy_scripts
+
+static func _set_plugin_settings(new_settings: Dictionary) -> void:
+	_plugin_settings = new_settings
+
+static func _get_plugin_settings() -> Dictionary:
+	return _plugin_settings
+
+#endregion
+
+#region Methods
+
+## The [method update_available_strategies] method uses the
+## [member _strategy_scripts] to update what [LokAccessStrategy] options
+## should be shown in the [ProjectSettings] as options to choose from.
+static func update_available_strategies() -> void:
+	_strategy_scripts = _load_strategy_scripts()
+	var available_strategies: Array[LokAccessStrategy] = _get_strategies()
+	var string_of_available_strategies: String = _get_strategies_enum_string()
+	var default_strategy_string: String = _get_default_strategy_name("Encrypted")
+	
+	_plugin_settings["addons/locker/access_strategy"]["property_info"]["hint_string"] = string_of_available_strategies
+	_plugin_settings["addons/locker/access_strategy"]["default_value"] = default_strategy_string
+	_plugin_settings["addons/locker/access_strategy"]["current_value"] = default_strategy_string
+
+## The [method save_settings] method takes a [param settings] [Dictionary] and
+## takes the current value of each one of them from the [ProjectSettings],
+## saving them in a [ConfigFile] in the [constant CONFIG_PATH].[br]
+## The [param settings] parameter has to conform to the structure explained in
+## the [member _plugin_settings] description.
+static func save_settings(settings: Dictionary) -> void:
+	if settings.is_empty():
+		return
+	
+	var config := ConfigFile.new()
+	var err: Error = config.load(CONFIG_PATH)
+	
+	for setting_path: String in settings:
+		var setting_data: Dictionary = settings[setting_path]
+		var setting_section: String = setting_data["config_section"]
+		var setting_name: String = setting_path.get_slice("/locker/", 1)
+		var setting_value: Variant = ProjectSettings.get_setting(
+			setting_path, setting_data["default_value"]
+		)
+		
+		config.set_value(setting_section, setting_name, setting_value)
+	
+	config.save(CONFIG_PATH)
+
+## The [method load_settings] method takes a [param settings] [Dictionary] and
+## loads the settings described by it from the [ConfigFile] in the
+## [constant CONFIG_PATH].
+## This method, then, sets the loaded settings in the [ProjectSettings].[br]
+## The [param settings] parameter has to conform to the structure explained in
+## the [member _plugin_settings] description.
+static func load_settings(settings: Dictionary = _plugin_settings) -> void:
+	var config := ConfigFile.new()
+	var err: Error = config.load(CONFIG_PATH)
+	
+	if err != OK:
+		return
+	
+	for setting_path: String in settings:
+		var setting_data: Dictionary = settings[setting_path]
+		var setting_section: String = setting_data["config_section"]
+		var setting_name: String = setting_path.get_slice("/locker/", 1)
+		var default_value: Variant = setting_data["default_value"]
+		
+		var new_value: Variant = config.get_value(
+			setting_section, setting_name, default_value
+		)
+		
+		if new_value != setting_data["current_value"]:
+			setting_data["current_value"] = new_value
+		
+		ProjectSettings.set_setting(setting_path, new_value)
+
+## The [method get_changed_settings] method takes a [param settings]
+## [Dictionary] and looks for settings that had their values changed.[br]
+## When found, their values are updated and they are returned.
+## The [param settings] parameter as well as the returned [Dictionary]
+## conform to the structure explained in the [member _plugin_settings]
+## description.
+static func get_changed_settings(settings: Dictionary = _plugin_settings) -> Dictionary:
+	var settings_changed: Dictionary = {}
+	
+	for setting_path: String in settings.keys():
+		var setting_data: Dictionary = settings[setting_path]
+		var default_value: Variant = setting_data["default_value"]
+		var new_value: Variant = ProjectSettings.get_setting(
+			setting_path, default_value
+		)
+		
+		if new_value != setting_data["current_value"]:
+			settings_changed[setting_path] = setting_data
+			
+			setting_data["current_value"] = new_value
+	
+	return settings_changed
+
+## The [method add_settings] method takes a [param settings]
+## [Dictionary] and saves each of its settings in the [ProjectSettings].[br]
+## The [param settings] parameter must conform to the structure explained
+## in the [member _plugin_settings] description.
+static func add_settings(settings: Dictionary = _plugin_settings) -> void:
+	for setting_path: String in settings.keys():
+		var setting: Dictionary = settings[setting_path]
+		
+		ProjectSettings.set_setting(setting_path, setting["default_value"])
+		ProjectSettings.set_initial_value(setting_path, setting["default_value"])
+		ProjectSettings.set_as_basic(setting_path, setting["is_basic"])
+		ProjectSettings.add_property_info(setting["property_info"])
+
+## The [method remove_settings] method takes a [param settings]
+## [Dictionary] and removes each of its settings from the [ProjectSettings].[br]
+## The [param settings] parameter must conform to the structure explained
+## in the [member _plugin_settings] description.
+static func remove_settings(settings: Dictionary = _plugin_settings) -> void:
+	for setting_path: String in settings.keys():
+		var setting: Dictionary = settings[setting_path]
+		
+		ProjectSettings.set_setting(setting_path, null)
+
+## The [method _load_strategy_scripts] method returns an [Array] of
+## [Script]s with the scripts that could be found in the path
+## pointed by the [constant STRATEGY_SCRIPTS_PATH] constant.
+static func _load_strategy_scripts() -> Array[Script]:
+	var scripts: Array[Script] = []
+	
+	for resource: Resource in LokFileSystemUtil.load_resources(STRATEGY_SCRIPTS_PATH, "Script"):
+		if not resource is Script:
+			continue
+		
+		scripts.append(resource as Script)
+	
+	return scripts
+
+## The [method _get_strategies] method returns an [Array] of
+## [LokAccessStrategy] instances got from the [Script]s in the
+## [member _strategy_scripts] property.
+static func _get_strategies() -> Array[LokAccessStrategy]:
+	var strategies: Array[LokAccessStrategy] = []
+	
+	for script: Script in _strategy_scripts:
+		var strategy: Object = script.new()
+		
+		if strategy is LokAccessStrategy:
+			strategies.append(strategy as LokAccessStrategy)
+	
+	return strategies
+
+## The [method _get_strategies_enum_string] method parses the
+## [LokAccessStrategy]s that the [LockerPlugin] knows into a [String]
+## that describes them in a way compatible with [code]hint_string[/code]s.
+static func _get_strategies_enum_string() -> String:
+	var result: String = ""
+	
+	var strategies: Array[LokAccessStrategy] = _get_strategies()
+	
+	for i: int in strategies.size():
+		var strategy: LokAccessStrategy = strategies[i]
+		
+		result += str(strategy)
+		
+		if i != strategies.size() - 1:
+			result += ","
+	
+	return result
+
+## The [method _get_default_strategy_name] method tries to get the
+## name of the [LokAccessStrategy] specified by the [param wanted_name]
+## parameter, so that name can be used in the [ProjectSettings] as the
+## default choice in the strategies enum.[br]
+## If there's no such [LokAccessStrategy] known by the [LockerPlugin], this
+## method will return any [LokAccessStrategy] name it knows, or even
+## an empty [String], if it doesn't know any [LokAccessStrategy]s.
+static func _get_default_strategy_name(wanted_name: String) -> String:
+	var result: String = ""
+	
+	var strategies: Array[LokAccessStrategy] = _get_strategies()
+	
+	for strategy: LokAccessStrategy in strategies:
+		var strategy_name: String = str(strategy)
+		
+		if strategy_name == wanted_name:
+			result = wanted_name
+			
+			return result
+	
+	if result == "" and not strategies.is_empty():
+		result = str(strategies[0])
+	
+	return result
+
+## The [method _string_to_strategy] method takes a [param string] and
+## returns a [LokAccessStrategy] that corresponds to that [param string].[br]
+## If an invalid [param string] is passed, this method returns
+## [code]null[/code].
+static func _string_to_strategy(string: String) -> LokAccessStrategy:
+	var strategies: Array[LokAccessStrategy] = _get_strategies()
+	
+	for strategy: LokAccessStrategy in strategies:
+		if string == str(strategy):
+			return strategy
+	
+	return null
+
+## The [method _strategy_to_string] method takes a [param strategy] and
+## returns a [String] that represents that [param strategy] in the
+## [code]"addons/locker/access_strategy"[/code] setting of the
+## [ProjectSettings].[br]
+## If an invalid [param strategy] is passed, this method returns
+## an empty [String].
+static func _strategy_to_string(strategy: LokAccessStrategy) -> String:
+	if strategy == null:
+		return ""
+	
+	return str(strategy)
+
+#endregion

--- a/addons/locker/scripts/storage_manager/global_storage_manager.gd
+++ b/addons/locker/scripts/storage_manager/global_storage_manager.gd
@@ -17,8 +17,8 @@ extends LokStorageManager
 ## directory where the save files should be accessed. [br]
 ## By default, this property initializes with the value from the
 ## [code]"addons/locker/saves_directory"[/code] setting in the [ProjectSettings]
-## (which is created by the [LockerPlugin]).
-var saves_directory: String = LockerPlugin.get_setting_saves_directory():
+## (which is created by the [LockerPlugin] using the [LokSettingsManager]).
+var saves_directory: String = LokSettingsManager.get_setting_saves_directory():
 	set = set_saves_directory,
 	get = get_saves_directory
 
@@ -26,8 +26,9 @@ var saves_directory: String = LockerPlugin.get_setting_saves_directory():
 ## the prefix that should be used in the save files when creating them. [br]
 ## By default, this property initializes with the value from the
 ## [code]"addons/locker/save_files_prefix"[/code] setting in the
-## [ProjectSettings] (which is created by the [LockerPlugin]).
-var save_files_prefix: String = LockerPlugin.get_setting_save_files_prefix():
+## [ProjectSettings] (which is created by the [LockerPlugin]
+## using the [LokSettingsManager]).
+var save_files_prefix: String = LokSettingsManager.get_setting_save_files_prefix():
 	set = set_save_files_prefix,
 	get = get_save_files_prefix
 
@@ -35,8 +36,9 @@ var save_files_prefix: String = LockerPlugin.get_setting_save_files_prefix():
 ## the format that should be used in the save files when accessing them. [br]
 ## By default, this property initializes with the value from the
 ## [code]"addons/locker/save_files_format"[/code] setting in the
-## [ProjectSettings] (which is created by the [LockerPlugin]).
-var save_files_format: String = LockerPlugin.get_setting_save_files_format():
+## [ProjectSettings] (which is created by the [LockerPlugin]
+## using the [LokSettingsManager]).
+var save_files_format: String = LokSettingsManager.get_setting_save_files_format():
 	set = set_save_files_format,
 	get = get_save_files_format
 
@@ -46,8 +48,9 @@ var save_files_format: String = LockerPlugin.get_setting_save_files_format():
 ## [LokStorageAccessorVersion]s. [br]
 ## By default, this property initializes with the value from the
 ## [code]"addons/locker/save_versions"[/code] setting in the
-## [ProjectSettings] (which is created by the [LockerPlugin]).
-var save_versions: bool = LockerPlugin.get_setting_save_versions():
+## [ProjectSettings] (which is created by the [LockerPlugin]
+## using the [LokSettingsManager]).
+var save_versions: bool = LokSettingsManager.get_setting_save_versions():
 	set = set_save_versions,
 	get = get_save_versions
 
@@ -117,14 +120,14 @@ func get_access_strategy() -> LokAccessStrategy:
 
 # Initializes values according to ProjectSettings
 func _init() -> void:
-	set_access_strategy(LockerPlugin.get_setting_access_strategy_parsed())
+	set_access_strategy(LokSettingsManager.get_setting_access_strategy_parsed())
 	
 	var access_strategy: LokAccessStrategy = get_access_strategy()
 	
 	if access_strategy != null:
 		access_strategy.set(
 			&"password",
-			LockerPlugin.get_setting_encrypted_strategy_password()
+			LokSettingsManager.get_setting_encrypted_strategy_password()
 		)
 
 # Finalizes AccessExecutor's Thread

--- a/test/unit/settings/test_settings_manager/test_settings_manager.gd
+++ b/test/unit/settings/test_settings_manager/test_settings_manager.gd
@@ -15,16 +15,16 @@ func load_scripts(path: String) -> Array[Script]:
 	return scripts
 
 func before_all() -> void:
-	_strategy_scripts = load_scripts(LockerPlugin.STRATEGY_SCRIPTS_PATH)
+	_strategy_scripts = load_scripts(LokSettingsManager.STRATEGY_SCRIPTS_PATH)
 
 func after_all() -> void:
 	queue_free()
 
 #region General behavior
 
-func test_locker_knows_strategies() -> void:
+func test_settings_manager_knows_strategies() -> void:
 	var expected: Array[Script] = _strategy_scripts
-	var result: Array[Script] = LockerPlugin._strategy_scripts
+	var result: Array[Script] = LokSettingsManager._strategy_scripts
 	
 	if expected.size() != result.size():
 		fail_test("Result had unexpected size")
@@ -37,18 +37,18 @@ func test_locker_knows_strategies() -> void:
 #region General Methods
 
 func test_set_setting_access_strategy_sets_JSON_strategy() -> void:
-	LockerPlugin.set_setting_access_strategy("JSON")
+	LokSettingsManager.set_setting_access_strategy("JSON")
 	
-	assert_eq(LockerPlugin.get_setting_access_strategy(), "JSON", "Unexpected strategy")
+	assert_eq(LokSettingsManager.get_setting_access_strategy(), "JSON", "Unexpected strategy")
 
 func test_get_setting_access_strategy_parsed_returns_JSON_strategy_instance() -> void:
-	LockerPlugin.set_setting_access_strategy("JSON")
+	LokSettingsManager.set_setting_access_strategy("JSON")
 	
-	assert_eq(str(LockerPlugin.get_setting_access_strategy_parsed()), "JSON", "Unexpected strategy")
+	assert_eq(str(LokSettingsManager.get_setting_access_strategy_parsed()), "JSON", "Unexpected strategy")
 
 func test_load_strategy_scripts_returns_scripts() -> void:
 	var expected: Array[Script] = _strategy_scripts
-	var result: Array[Script] = LockerPlugin._load_strategy_scripts()
+	var result: Array[Script] = LokSettingsManager._load_strategy_scripts()
 	
 	if expected.size() != result.size():
 		fail_test("Result had unexpected size")
@@ -64,7 +64,7 @@ func test_get_strategies_returns_strategy_instances() -> void:
 	
 	var result_str: Array[String] = []
 	
-	for strategy: LokAccessStrategy in LockerPlugin._get_strategies():
+	for strategy: LokAccessStrategy in LokSettingsManager._get_strategies():
 		result_str.append(str(strategy))
 	
 	if expected_str.size() != result_str.size():
@@ -84,7 +84,7 @@ func test_get_strategies_enum_string_includes_all_strategies() -> void:
 		if i != _strategy_scripts.size() - 1:
 			expected += ","
 	
-	var result: String = LockerPlugin._get_strategies_enum_string()
+	var result: String = LokSettingsManager._get_strategies_enum_string()
 	
 	assert_eq(result, expected, "Unexpected enum")
 
@@ -95,15 +95,15 @@ func test_get_strategies_enum_string_includes_all_strategies() -> void:
 func test_get_default_strategy_name_returns_whichever_if_not_found() -> void:
 	var strategy_names: Array[String] = []
 	
-	for strategy: LokAccessStrategy in LockerPlugin._get_strategies():
+	for strategy: LokAccessStrategy in LokSettingsManager._get_strategies():
 		strategy_names.append(str(strategy))
 	
-	var result: String = LockerPlugin._get_default_strategy_name("Unexisting")
+	var result: String = LokSettingsManager._get_default_strategy_name("Unexisting")
 	
 	assert_true(strategy_names.has(result), "Invalid strategy name")
 
 func test_get_default_strategy_name_returns_wanted_name() -> void:
-	var result: String = LockerPlugin._get_default_strategy_name("JSON")
+	var result: String = LokSettingsManager._get_default_strategy_name("JSON")
 	
 	assert_eq(result, "JSON", "JSON strategy not found")
 
@@ -112,17 +112,17 @@ func test_get_default_strategy_name_returns_wanted_name() -> void:
 #region _string_to_strategy
 
 func test_string_to_strategy_parses_encrypted_strategy() -> void:
-	var result: LokAccessStrategy = LockerPlugin._string_to_strategy("Encrypted")
+	var result: LokAccessStrategy = LokSettingsManager._string_to_strategy("Encrypted")
 	
 	assert_eq(str(result), "Encrypted", "Unexpected strategy")
 
 func test_string_to_strategy_parses_json_strategy() -> void:
-	var result: LokAccessStrategy = LockerPlugin._string_to_strategy("JSON")
+	var result: LokAccessStrategy = LokSettingsManager._string_to_strategy("JSON")
 	
 	assert_eq(str(result), "JSON", "Unexpected strategy")
 
 func test_string_to_strategy_doesnt_parse_unknown_strategy() -> void:
-	var result: LokAccessStrategy = LockerPlugin._string_to_strategy("Unknown")
+	var result: LokAccessStrategy = LokSettingsManager._string_to_strategy("Unknown")
 	
 	assert_null(result, "Unexpected strategy")
 
@@ -131,12 +131,12 @@ func test_string_to_strategy_doesnt_parse_unknown_strategy() -> void:
 #region Method _strategy_to_string
 
 func test_strategy_to_string_parses_encrypted_strategy() -> void:
-	var result: String = LockerPlugin._strategy_to_string(LokEncryptedAccessStrategy.new())
+	var result: String = LokSettingsManager._strategy_to_string(LokEncryptedAccessStrategy.new())
 	
 	assert_eq(result, "Encrypted", "Unexpected strategy")
 
 func test_strategy_to_string_parses_json_strategy() -> void:
-	var result: String = LockerPlugin._strategy_to_string(LokJSONAccessStrategy.new())
+	var result: String = LokSettingsManager._strategy_to_string(LokJSONAccessStrategy.new())
 	
 	assert_eq(result, "JSON", "Unexpected strategy")
 

--- a/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
+++ b/test/unit/storage_manager/test_global_storage_manager/test_global_storage_manager.gd
@@ -27,12 +27,12 @@ func after_all() -> void:
 #region General behavior
 
 func test_initializes_with_project_settings() -> void:
-	var expected_saves_directory: String = LockerPlugin.get_setting_saves_directory()
-	var expected_save_files_prefix: String = LockerPlugin.get_setting_save_files_prefix()
-	var expected_save_files_format: String = LockerPlugin.get_setting_save_files_format()
-	var expected_save_versions: bool = LockerPlugin.get_setting_save_versions()
-	var expected_access_strategy: String = LockerPlugin.get_setting_access_strategy()
-	var expected_encrypted_strategy_password: String = LockerPlugin.get_setting_encrypted_strategy_password()
+	var expected_saves_directory: String = LokSettingsManager.get_setting_saves_directory()
+	var expected_save_files_prefix: String = LokSettingsManager.get_setting_save_files_prefix()
+	var expected_save_files_format: String = LokSettingsManager.get_setting_save_files_format()
+	var expected_save_versions: bool = LokSettingsManager.get_setting_save_versions()
+	var expected_access_strategy: String = LokSettingsManager.get_setting_access_strategy()
+	var expected_encrypted_strategy_password: String = LokSettingsManager.get_setting_encrypted_strategy_password()
 	
 	var saves_directory: String = manager.get_saves_directory()
 	var save_files_prefix: String = manager.get_save_files_prefix()
@@ -48,7 +48,7 @@ func test_initializes_with_project_settings() -> void:
 	assert_eq(save_files_prefix, expected_save_files_prefix, "Unexpected value")
 	assert_eq(save_files_format, expected_save_files_format, "Unexpected value")
 	assert_eq(save_versions, expected_save_versions, "Unexpected value")
-	assert_eq(LockerPlugin._strategy_to_string(access_strategy), expected_access_strategy, "Unexpected value")
+	assert_eq(LokSettingsManager._strategy_to_string(access_strategy), expected_access_strategy, "Unexpected value")
 	
 	if expected_access_strategy == "Encrypted":
 		assert_eq(encrypted_strategy_password, expected_encrypted_strategy_password, "Unexpected value")


### PR DESCRIPTION
## Overview
<!-- Provide a clear and concise description of the changes in this PR. -->
This Pull Request fixes a dependency that existed between the `GlobalStorageManager` and the `LockerPlugin`, which inherits the `EditorPlugin`. This fix was needed because `EditorPlugin`s don't exist on exported projects, which caused the `GlobalStorageManager` to not compile, since it needed an unexistent `EditorPlugin`.

## Related Issues
<!-- Link any Issues addressed by this PR (e.g., fixes #123, closes #456) -->
fixes #33 

## Checklist
- [X] This code follows the project's coding style.
- [X] I have tested my changes in Godot (mention the version used).
- [X] I have updated the documentation (if applicable).
- [X] I have added tests (if applicable).
- [X] This PR does not introduce new warnings or errors.

## What was changed
<!-- Explain what and why was added, changed or removed with this PR, including screenshots, or other related content, if applicable. -->
- Moved settings management methods from the `LockerPlugin` to a new `LokSettingsManager` class, which is available in exported builds and refactored the necessary classes and tests.

## How to Test
<!-- Provide steps to test this PR. -->
The new changes can be tested with the unit tests that were adapted with this **PR**.
